### PR TITLE
Hide internal IDs in filters

### DIFF
--- a/app/incidents/annotations.cds
+++ b/app/incidents/annotations.cds
@@ -8,7 +8,7 @@ annotate service.Incidents with @(
             {
                 $Type: 'UI.DataField',
                 Label: '{i18n>Customerid}',
-                Value: customer_ID,
+                Value: customer.name,
             },
             {
                 $Type: 'UI.DataField',
@@ -137,6 +137,7 @@ annotate service.Incidents with {
         Common.Label                   : '{i18n>Statuscode}',
         Common.ValueListWithFixedValues: true,
         Common.Text                    : status.descr,
+        UI.TextArrangement             : #TextOnly,
     )
 };
 
@@ -145,6 +146,7 @@ annotate service.Incidents with {
         Common.Label                   : '{i18n>Urgencycode}',
         Common.ValueListWithFixedValues: true,
         Common.Text                    : urgency.descr,
+        UI.TextArrangement             : #TextOnly,
     )
 };
 
@@ -189,3 +191,8 @@ annotate service.Comments with @(UI.LineItem #Comments: [
         Label: '{i18n>CreatedAt}'
     },
 ]);
+
+annotate service.Incidents with {
+    ID @(UI.HiddenFilter);
+    customer_ID @(UI.HiddenFilter);
+};

--- a/srv/cat-service.cds
+++ b/srv/cat-service.cds
@@ -34,3 +34,8 @@ service AdminService {
 }
 
 annotate ProcessorService.Incidents with @odata.draft.enabled;
+
+annotate ProcessorService.Incidents with {
+    ID @UI.Hidden, @UI.HiddenFilter;
+    customer_ID @UI.Hidden, @UI.HiddenFilter;
+};


### PR DESCRIPTION
## Summary
- hide technical ID fields from UI filters

## Testing
- `git status --short`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6857fdc45bd88325ab97e10dcb1b35fa