### PR TITLE
Add dynamic status icons to Object Page

### DIFF
--- a/app/incidents/annotations.cds
+++ b/app/incidents/annotations.cds
@@ -98,7 +98,7 @@ annotate service.Incidents with @(
             $Type: 'UI.DataField',
             Value: customer.name,
         },
-        TypeImageUrl  : 'sap-icon://alert',
+        TypeImageUrl  : { $Path: 'statusImageUrl' },
     }
 );
 

--- a/srv/cat-service.cds
+++ b/srv/cat-service.cds
@@ -5,7 +5,10 @@ using {sap.capire.incidents as my} from '../db/schema';
  */
 service ProcessorService {
     @cds.redirection.target
-    entity Incidents       as projection on my.Incidents;
+    entity Incidents       as projection on my.Incidents {
+        *,
+        statusImageUrl : String;
+    };
 
     @readonly
     entity ListOfIncidents as
@@ -28,7 +31,10 @@ service AdminService {
     entity Customers as projection on my.Customers;
 
     @cds.redirection.target
-    entity Incidents as projection on my.Incidents;
+    entity Incidents as projection on my.Incidents {
+        *,
+        statusImageUrl : String;
+    };
 
     entity Comments  as projection on my.Comments;
 }

--- a/srv/cat-service.js
+++ b/srv/cat-service.js
@@ -1,0 +1,36 @@
+const cds = require('@sap/cds')
+
+module.exports = cds.service.impl(function () {
+  const { Incidents } = this.entities
+
+  this.after('READ', Incidents, (each) => {
+    const rows = Array.isArray(each) ? each : [each]
+    for (const row of rows) setImage(row)
+  })
+
+  function setImage (row) {
+    if (!row) return
+    switch (row.status_code) {
+      case 'N':
+        row.statusImageUrl = 'sap-icon://status-inactive'
+        break
+      case 'A':
+        row.statusImageUrl = 'sap-icon://status-in-process'
+        break
+      case 'I':
+        row.statusImageUrl = 'sap-icon://activate'
+        break
+      case 'H':
+        row.statusImageUrl = 'sap-icon://pending'
+        break
+      case 'R':
+        row.statusImageUrl = 'sap-icon://accept'
+        break
+      case 'C':
+        row.statusImageUrl = 'sap-icon://decline'
+        break
+      default:
+        row.statusImageUrl = 'sap-icon://question-mark'
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- expose `statusImageUrl` in the service projections
- return icon URLs in service implementation based on `status_code`
- bind ObjectPage header image to `statusImageUrl`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685827a498748325be7673c0197ff67c