### PR TITLE
Add ListOfIncidents standard list report

### DIFF
--- a/app/listofincidents/README.md
+++ b/app/listofincidents/README.md
@@ -1,0 +1,35 @@
+## Application Details
+|               |
+| ------------- |
+|**Generation Date and Time**<br>Mon Jun 23 2025 14:36:00 GMT+0000 (Coordinated Universal Time)|
+|**App Generator**<br>SAP Fiori Application Generator|
+|**App Generator Version**<br>1.18.0|
+|**Generation Platform**<br>SAP Business Application Studio|
+|**Template Used**<br>List Report V4|
+|**Service Type**<br>Local Cap|
+|**Service URL**<br>http://localhost:4004/odata/v4/processor/|
+|**Module Name**<br>listofincidents|
+|**Application Title**<br>List Of Incidents|
+|**Namespace**<br>ns|
+|**UI5 Theme**<br>sap_horizon|
+|**UI5 Version**<br>1.136.2|
+|**Enable Code Assist Libraries**<br>False|
+|**Enable TypeScript**<br>False|
+|**Add Eslint configuration**<br>False|
+|**Main Entity**<br>ListOfIncidents|
+|**Navigation Entity**<br>None|
+
+## listofincidents
+
+An SAP Fiori application.
+
+### Starting the generated app
+
+-   This app has been generated using the SAP Fiori tools - App Generator. In order to launch the generated app, simply start your CAP project and navigate to the following location in your browser:
+
+http://localhost:4004/listofincidents/webapp/index.html
+
+#### Pre-requisites:
+
+1. Active NodeJS LTS (Long Term Support) version and associated supported NPM version.  (See https://nodejs.org)
+

--- a/app/listofincidents/annotations.cds
+++ b/app/listofincidents/annotations.cds
@@ -1,0 +1,9 @@
+using ProcessorService as service from '../../srv/cat-service';
+
+annotate service.ListOfIncidents with @(
+    UI.LineItem: [
+        { $Type: 'UI.DataField', Value: title, Label: '{i18n>Title}' },
+        { $Type: 'UI.DataField', Value: customer.name, Label: '{i18n>CustomerName}' }
+    ],
+    UI.SelectionFields: [ title ]
+);

--- a/app/listofincidents/package.json
+++ b/app/listofincidents/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "listofincidents",
+  "version": "0.0.1",
+  "description": "Fiori elements List Report for ListOfIncidents",
+  "dependencies": {},
+  "devDependencies": {
+    "@ui5/cli": "^3.0.0",
+    "@sap/ux-ui5-tooling": "1",
+    "ui5-task-zipper": "^3.4.x"
+  },
+  "scripts": {
+    "build:cf": "ui5 build preload --clean-dest --config ui5-deploy.yaml --include-task=generateCachebusterInfo"
+  }
+}

--- a/app/listofincidents/ui5-deploy.yaml
+++ b/app/listofincidents/ui5-deploy.yaml
@@ -1,0 +1,20 @@
+specVersion: "3.1"
+metadata:
+  name: ns.listofincidents
+type: application
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
+builder:
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**
+  customTasks:
+    - name: ui5-task-zipper
+      afterTask: generateCachebusterInfo
+      configuration:
+        archiveName: nslistofincidents
+        relativePaths: true
+        additionalFiles:
+          - xs-app.json

--- a/app/listofincidents/ui5.yaml
+++ b/app/listofincidents/ui5.yaml
@@ -1,0 +1,21 @@
+specVersion: "3.1"
+metadata:
+  name: ns.listofincidents
+type: application
+server:
+  customMiddleware:
+    - name: fiori-tools-proxy
+      afterMiddleware: compression
+      configuration:
+        ignoreCertError: false
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://sapui5.hana.ondemand.com
+    - name: fiori-tools-appreload
+      afterMiddleware: compression
+      configuration:
+        port: 35729
+        path: webapp
+        delay: 300

--- a/app/listofincidents/webapp/Component.js
+++ b/app/listofincidents/webapp/Component.js
@@ -1,0 +1,11 @@
+sap.ui.define([
+    "sap/fe/core/AppComponent"
+], function (AppComponent) {
+    "use strict";
+
+    return AppComponent.extend("ns.listofincidents.Component", {
+        metadata: {
+            manifest: "json"
+        }
+    });
+});

--- a/app/listofincidents/webapp/i18n/i18n.properties
+++ b/app/listofincidents/webapp/i18n/i18n.properties
@@ -1,0 +1,4 @@
+appTitle=List Of Incidents
+appDescription=Simple list of incidents
+Title=Title
+CustomerName=Customer

--- a/app/listofincidents/webapp/index.html
+++ b/app/listofincidents/webapp/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>List Of Incidents</title>
+    <style>
+        html, body, body > div, #container, #container-uiarea {
+            height: 100%;
+        }
+    </style>
+    <script
+        id="sap-ui-bootstrap"
+        src="https://sapui5.hana.ondemand.com/1.136.2/resources/sap-ui-core.js"
+        data-sap-ui-theme="sap_horizon"
+        data-sap-ui-resourceroots='{"ns.listofincidents": "./"}'
+        data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
+        data-sap-ui-compatVersion="edge"
+        data-sap-ui-async="true"
+        data-sap-ui-frameOptions="trusted"
+    ></script>
+</head>
+<body class="sapUiBody sapUiSizeCompact" id="content">
+    <div
+        data-sap-ui-component
+        data-name="ns.listofincidents"
+        data-id="container"
+        data-settings='{"id" : "ns.listofincidents"}'
+        data-handle-validation="true"
+    ></div>
+</body>
+</html>

--- a/app/listofincidents/webapp/manifest.json
+++ b/app/listofincidents/webapp/manifest.json
@@ -1,0 +1,116 @@
+{
+  "_version": "1.65.0",
+  "sap.app": {
+    "id": "ns.listofincidents",
+    "type": "application",
+    "i18n": "i18n/i18n.properties",
+    "applicationVersion": {
+      "version": "0.0.1"
+    },
+    "title": "{{appTitle}}",
+    "description": "{{appDescription}}",
+    "resources": "resources.json",
+    "sourceTemplate": {
+      "id": "@sap/generator-fiori:lr",
+      "version": "1.18.0"
+    },
+    "dataSources": {
+      "mainService": {
+        "uri": "/odata/v4/processor/",
+        "type": "OData",
+        "settings": {
+          "annotations": [],
+          "odataVersion": "4.0"
+        }
+      }
+    }
+  },
+  "sap.ui": {
+    "technology": "UI5",
+    "icons": {},
+    "deviceTypes": {
+      "desktop": true,
+      "tablet": true,
+      "phone": true
+    }
+  },
+  "sap.ui5": {
+    "flexEnabled": true,
+    "dependencies": {
+      "minUI5Version": "1.136.2",
+      "libs": {
+        "sap.m": {},
+        "sap.ui.core": {},
+        "sap.fe.templates": {}
+      }
+    },
+    "models": {
+      "i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "settings": {
+          "bundleName": "ns.listofincidents.i18n.i18n"
+        }
+      },
+      "": {
+        "dataSource": "mainService",
+        "preload": true,
+        "settings": {
+          "operationMode": "Server",
+          "autoExpandSelect": true,
+          "earlyRequests": true
+        }
+      }
+    },
+    "routing": {
+      "config": {
+        "routerClass": "sap.f.routing.Router"
+      },
+      "routes": [
+        {
+          "pattern": ":?query:",
+          "name": "ListOfIncidents",
+          "target": [
+            "ListOfIncidents"
+          ]
+        }
+      ],
+      "targets": {
+        "ListOfIncidents": {
+          "type": "Component",
+          "id": "ListOfIncidents",
+          "name": "sap.fe.templates.ListReport",
+          "options": {
+            "settings": {
+              "contextPath": "/ListOfIncidents",
+              "variantManagement": "Page",
+              "controlConfiguration": {
+                "@com.sap.vocabularies.UI.v1.LineItem": {
+                  "tableSettings": {
+                    "type": "ResponsiveTable"
+                  }
+                }
+              },
+              "initialLoad": "Enabled"
+            }
+          },
+          "controlAggregation": "pages",
+          "contextPattern": ""
+        }
+      }
+    },
+    "rootView": {
+      "viewName": "sap.fe.templates.RootContainer.view.App",
+      "type": "XML",
+      "async": true,
+      "id": "appRootView"
+    }
+  },
+  "sap.fiori": {
+    "registrationIds": [],
+    "archeType": "transactional"
+  },
+  "sap.cloud": {
+    "public": true,
+    "service": "btp_levelup.service"
+  }
+}

--- a/app/listofincidents/xs-app.json
+++ b/app/listofincidents/xs-app.json
@@ -1,0 +1,31 @@
+{
+  "welcomeFile": "/index.html",
+  "authenticationMethod": "route",
+  "routes": [
+    {
+      "source": "^/odata/(.*)$",
+      "target": "/odata/$1",
+      "destination": "btp_levelup-auth",
+      "authenticationType": "xsuaa",
+      "csrfProtection": false
+    },
+    {
+      "source": "^/resources/(.*)$",
+      "target": "/resources/$1",
+      "authenticationType": "none",
+      "destination": "ui5"
+    },
+    {
+      "source": "^/test-resources/(.*)$",
+      "target": "/test-resources/$1",
+      "authenticationType": "none",
+      "destination": "ui5"
+    },
+    {
+      "source": "^(.*)$",
+      "target": "$1",
+      "service": "html5-apps-repo-rt",
+      "authenticationType": "xsuaa"
+    }
+  ]
+}

--- a/mta.yaml
+++ b/mta.yaml
@@ -62,6 +62,10 @@ modules:
       - nsincidents.zip
       name: nsincidents
       target-path: app/
+    - artifacts:
+      - nslistofincidents.zip
+      name: nslistofincidents
+      target-path: app/
 - name: btp_levelup-destinations
   type: com.sap.application.content
   requires:
@@ -96,6 +100,16 @@ modules:
 - name: nsincidents
   type: html5
   path: app/incidents
+  build-parameters:
+    build-result: dist
+    builder: custom
+    commands:
+    - npm install
+    - npm run build:cf
+    supported-platforms: []
+- name: nslistofincidents
+  type: html5
+  path: app/listofincidents
   build-parameters:
     build-result: dist
     builder: custom

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     }
   },
   "sapux": [
-    "app/incidents"
+    "app/incidents",
+    "app/listofincidents"
   ]
 }


### PR DESCRIPTION
## Summary
- convert `listofincidents` UI module to a Fiori elements List Report
- remove freestyle controller and view
- provide minimal annotations for the ListOfIncidents entity

## Testing
- `jq . app/listofincidents/webapp/manifest.json`

------
https://chatgpt.com/codex/tasks/task_b_685964cfe9908325839f934294d002d2